### PR TITLE
chore: update pipelines service

### DIFF
--- a/compose.pipelines.yml
+++ b/compose.pipelines.yml
@@ -6,7 +6,7 @@ services:
       - ./.env
       - ./pipelines/override.env
     volumes:
-      - ./pipelines/default:/app/pipelines
+      - ./pipelines/persistent:${HARBOR_PIPELINES_DIR}
     entrypoint: [ "/bin/bash", "/app/start.sh" ]
     # NOTE: Currently pipelines doesn't have an `/health` endpoint and logs requests to `/`.
     # Consider disabling healthcheck if you need clear logs.


### PR DESCRIPTION
Thank you so much for merging #76, and fixing the persistency issue with pipelines. Small follow up for [155ba8f](https://github.com/ic4l4s9c/harbor/commit/155ba8f172be369de1d46b6a0abc88d4d71f6b62).
I think the more correct solution would be to mount persistent volume to directory specified with `HARBOR_PIPELINES_DIR` environment variable.