### PR TITLE
Fix harbor.sh parsing of docker desktop version

### DIFF
--- a/harbor.sh
+++ b/harbor.sh
@@ -241,7 +241,7 @@ has_nvidia_ctk() {
 }
 
 has_modern_compose() {
-    local compose_version=$(docker compose version --short)
+    local compose_version=$(docker compose version --short | sed -e 's/-desktop//' )
     local major_version=$(echo "$compose_version" | cut -d. -f1)
     local minor_version=$(echo "$compose_version" | cut -d. -f2)
     local patch_version=$(echo "$compose_version" | cut -d. -f3)


### PR DESCRIPTION
Output of `docker compose version` looks like this under wsl:
```
$ docker compose version
Docker Compose version v2.31.0-desktop.2
```
This causes a warning when treating `patch_version` as numeric because it's `0-desktop`