### PR TITLE
Update start_aider.sh - fix location of aider config files

### DIFF
--- a/aider/start_aider.sh
+++ b/aider/start_aider.sh
@@ -7,10 +7,10 @@ echo "Harbor: custom aider entrypoint"
 python --version
 
 echo "YAML Merger is starting..."
-python /root/.aider/yaml_config_merger.py --pattern ".yml" --output "/root/.aider.conf.yml" --directory "/root/.aider"
+python /home/appuser/.aider/yaml_config_merger.py --pattern ".yml" --output "/home/appuser/.aider.conf.yml" --directory "/home/appuser/.aider"
 
 echo "Merged Configs:"
-cat /root/.aider.conf.yml
+cat /home/appuser/.aider.conf.yml
 
 git config --global --add safe.directory /root/workspace
 


### PR DESCRIPTION
aider config files are located in /home/appuser as specified by the docker config, not in /root. Fixed in this PR.