### PR TITLE
Fix plandex service definitions

### DIFF
--- a/harbor.sh
+++ b/harbor.sh
@@ -2646,7 +2646,7 @@ run_plandex_command() {
     case "$1" in
     health)
         shift
-        execute_and_process "get_url plandexserver" "curl {{output}}/health" "No plandexserver URL:"
+        execute_and_process "get_url plandex-server" "curl {{output}}/health" "No plandexserver URL:"
         ;;
     pwd)
         shift

--- a/plandex/Dockerfile
+++ b/plandex/Dockerfile
@@ -1,6 +1,9 @@
-FROM pkgxdev/pkgx
+FROM alpine
 
-RUN pkgx install curl vim.org
-RUN curl -sL https://plandex.ai/install.sh | bash
+RUN apk update
+RUN apk add bash
+RUN apk add curl
+RUN wget https://plandex.ai/install.sh
+RUN bash install.sh
 
 ENTRYPOINT plandex


### PR DESCRIPTION
Trying to set up plandex through harbor, I found 2 errors:

1. Dockerfile for building Dockerized plandex-cli  was not working. Internal "pkgx" package manager was not properly installing "curl", as seen in the output below: <br> 
```
heron@samsung-np350xaa:~/harbor$ harbor up plandex
[+] Building 39.6s (5/6)                                                                                                                                                   docker:default
 => [plandex internal] load build definition from Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 155B                                                                                                                                                 0.0s
 => [plandex internal] load metadata for docker.io/pkgxdev/pkgx:latest                                                                                                               3.3s
 => [plandex internal] load .dockerignore                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => [plandex 1/3] FROM docker.io/pkgxdev/pkgx:latest@sha256:4f7d70c2568ecbedab0fb2f60264629e9b0f2b6939f498ecfc35400e59a89f3a                                                        28.5s
 => => resolve docker.io/pkgxdev/pkgx:latest@sha256:4f7d70c2568ecbedab0fb2f60264629e9b0f2b6939f498ecfc35400e59a89f3a                                                                 0.0s
 => => sha256:1695dd3077a0cca004b3815294040cb05b073dd7f55bbbf8505ca750040f9d62 1.24kB / 1.24kB                                                                                       0.0s
 => => sha256:de9fc025803adc8190b17c31a70d4299d52d14d9e7913272a3321d66a934c966 2.40kB / 2.40kB                                                                                       0.0s
 => => sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33 27.34MB / 27.34MB                                                                                    25.4s
 => => sha256:6a45b78bd205c4c9cfd30721b76ccb24b8e1f6b541a471953196a1bb823f2131 37.02MB / 37.02MB                                                                                    24.5s
 => => sha256:400681f25a64cf56c6679c963990e7ff5c423bd5e650d608d5ce7362f064856d 5.19MB / 5.19MB                                                                                       4.6s
 => => sha256:4f7d70c2568ecbedab0fb2f60264629e9b0f2b6939f498ecfc35400e59a89f3a 1.61kB / 1.61kB                                                                                       0.0s
 => => sha256:ecab6e847c2a02c8aafca7f98e100c74a216ee4fb81115e3063af83d0c715d9a 3.04kB / 3.04kB                                                                                       5.4s
 => => sha256:ca153950752d50c35053b6e20730f99702ac9e31bdbf1fd35970911681631bfe 516B / 516B                                                                                           6.5s
 => => extracting sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33                                                                                            1.4s
 => => extracting sha256:6a45b78bd205c4c9cfd30721b76ccb24b8e1f6b541a471953196a1bb823f2131                                                                                            1.3s
 => => extracting sha256:400681f25a64cf56c6679c963990e7ff5c423bd5e650d608d5ce7362f064856d                                                                                            0.1s
 => => extracting sha256:ecab6e847c2a02c8aafca7f98e100c74a216ee4fb81115e3063af83d0c715d9a                                                                                            0.0s
 => => extracting sha256:ca153950752d50c35053b6e20730f99702ac9e31bdbf1fd35970911681631bfe                                                                                            0.0s
 => ERROR [plandex 2/3] RUN pkgx install curl vim.org                                                                                                                                7.7s
------
 > [plandex 2/3] RUN pkgx install curl vim.org:
6.861 install: cannot stat 'curl': No such file or directory
------
failed to solve: process "/bin/bash -c pkgx install curl vim.org" did not complete successfully: exit code: 1
```
2. There was an incorrect reference for plandex-server in the command "run_plandex_command" (harbor.sh). When I tried to run "harbor plandex health", harbor incorrectly was telling that no plandex server had been found. The root cause was that "get_url" function call parameter was incorrect. It was "plandexserver", but the container name was "plandex-server".