### PR TITLE
fix: fix qrgen image failing to build

### DIFF
--- a/qrgen/Dockerfile
+++ b/qrgen/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /app
 RUN pkgx +node@20 npm install qrcode-terminal
 COPY ./gen.ts /app/gen.ts
 # Activate pkgx env
-RUN pkgx gen.ts test
+RUN pkgx deno gen.ts test
 
-ENTRYPOINT [ "pkgx", "gen.ts" ]
+ENTRYPOINT [ "pkgx", "deno", "gen.ts" ]


### PR DESCRIPTION
# Description
This pull request fixes an issue where the qrgen Docker image fails to build due to the following error:
```
> [qrgen 5/5] RUN pkgx gen.ts test:
3.064 Error: CmdNotFound("gen.ts")
```

The issue occurs because pkgx does not recognize gen.ts as an executable by default. The fix ensures that the script runs explicitly using deno.

# Changes Made
- Updated Dockerfile to use pkgx deno gen.ts test instead of pkgx gen.ts test.
- Modified ENTRYPOINT to call pkgx deno gen.ts.

# Fixes
Closes #136 

# Testing Done
After applying this fix, running harbor tunnel webui successfully prints the QR code instead of failing during the image build.
