### PR TITLE
bump golang >= 1.24.0

### DIFF
--- a/fabric/Dockerfile
+++ b/fabric/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4
+FROM golang:1.24.4
 
 WORKDIR /app
 RUN go install github.com/danielmiessler/fabric@latest


### PR DESCRIPTION
`harbor build fabric` would die with an error stating go needed to be >= 1.24.0.  This fixes that.