### PR TITLE
fix: improve sed portability across GNU and BSD implementations

### DIFF
--- a/harbor.sh
+++ b/harbor.sh
@@ -1363,11 +1363,9 @@ env_manager() {
         shift 2          # Remove 'set' and the key from the arguments
         local value="$*" # Capture all remaining arguments as the value
         if grep -q "^$prefix$upper_key=" "$env_file"; then
-            if [[ "$(uname)" == "Darwin" ]]; then
-                sed -i '' "s|^$prefix$upper_key=.*|$prefix$upper_key=\"$value\"|" "$env_file"
-            else
-                sed -i "s|^$prefix$upper_key=.*|$prefix$upper_key=\"$value\"|" "$env_file"
-            fi
+            # Use temp file approach for portability across GNU and BSD sed
+            local temp_file=$(mktemp)
+            sed "s|^$prefix$upper_key=.*|$prefix$upper_key=\"$value\"|" "$env_file" > "$temp_file" && mv "$temp_file" "$env_file"
         else
             echo "$prefix$upper_key=\"$value\"" >>"$env_file"
         fi


### PR DESCRIPTION
## Summary
  - Fix sed compatibility issues that occur when users have GNU sed installed (common on macOS via Homebrew)
  - Replace OS-based detection with portable temp file approach
  - Eliminates "can't read s|pattern|replacement|: No such file or directory" errors

  ## Problem
  The original code used `uname` to detect macOS and assumed BSD sed, but:
  - Homebrew users on macOS often install GNU sed as default
  - GNU sed and BSD sed have different `-i` (in-place) syntax
  - This caused sed to misinterpret replacement patterns as filenames

  ## Solution
  - Use temp file approach: `sed pattern file > temp && mv temp file`
  - Works consistently across both GNU and BSD sed implementations
  - No more OS-specific conditional logic needed
  - Eliminates backup file syntax differences

  ## Test plan
  - [x] Tested with GNU sed (Homebrew default)
  - [x] Tested with BSD sed (`/usr/bin/sed`)
  - [x] Verified `harbor.sh ln` works without errors
  - [x] Confirmed no backup files are created
  - [x] Rebased against latest main branch
