### PR TITLE
fix: enable Docker network access for package registries on Linux

### DIFF
--- a/compose.dify.yml
+++ b/compose.dify.yml
@@ -162,6 +162,7 @@ services:
     build:
       context: ./dify/openai
       dockerfile: Dockerfile
+      network: host
     container_name: ${HARBOR_CONTAINER_PREFIX}.dify-openai
     ports:
       - ${HARBOR_DIFY_D2O_HOST_PORT}:3000

--- a/harbor.sh
+++ b/harbor.sh
@@ -347,6 +347,7 @@ run_routine() {
 
     log_debug "Running routine: $routine_name"
     docker run --rm \
+        --network=host \
         -v "$harbor_home:$harbor_home" \
         -v harbor-deno-cache:/deno-dir:rw \
         -w "$harbor_home" \

--- a/routines/deno.lock
+++ b/routines/deno.lock
@@ -3,7 +3,8 @@
   "specifiers": {
     "jsr:@std/collections@*": "1.0.10",
     "jsr:@std/fmt@*": "1.0.5",
-    "jsr:@std/yaml@*": "1.0.5"
+    "jsr:@std/yaml@*": "1.0.5",
+    "npm:@types/node@*": "22.15.15"
   },
   "jsr": {
     "@std/collections@1.0.10": {
@@ -14,6 +15,17 @@
     },
     "@std/yaml@1.0.5": {
       "integrity": "71ba3d334305ee2149391931508b2c293a8490f94a337eef3a09cade1a2a2742"
+    }
+  },
+  "npm": {
+    "@types/node@22.15.15": {
+      "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "undici-types@6.21.0": {
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     }
   }
 }


### PR DESCRIPTION
## Summary
• Fixes Docker network access issues on Linux preventing npm and JSR package downloads
• Adds `--network=host` to Deno routine containers for JSR registry access  
• Adds `network: host` to dify-openai Docker build for npm registry access during builds

## Test plan
- [x] Verify `harbor ls` works on Linux (JSR registry access)
- [x] Verify `harbor up dify` builds successfully without hanging on npm install
- [x] Test both fixes on Linux systems where Docker networking is more restrictive

## Context
Docker on Linux uses bridge networking by default which can block container access to external package registries. This causes:
- Harbor routines to fail when downloading JSR dependencies like @std/yaml
- Dify builds to hang during `npm install` when building the dify-openai service

Both fixes apply the same solution (`network: host`) at different stages:
1. Runtime network access for short-lived utility containers (routines)  
2. Build-time network access for Docker image builds

🤖 Generated with [Claude Code](https://claude.ai/code)