### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/5.2.2-Harbor-Boost-Configuration.md
+++ b/docs/5.2.2-Harbor-Boost-Configuration.md
@@ -84,8 +84,8 @@ HARBOR_BOOST_OPENAI_KEY_HF=sk-hf456
 
 MiniMax API key. When set, the MiniMax OpenAI-compatible
 endpoint (https://api.minimax.io/v1) is automatically
-registered as a boost backend with MiniMax-M2.7,
-MiniMax-M2.7-highspeed, and previous MiniMax models.
+registered as a boost backend with MiniMax-M3 (default),
+MiniMax-M2.7, and MiniMax-M2.7-highspeed.
 
 
 ## HARBOR_BOOST_EXTRA_LLM_PARAMS

--- a/services/boost/src/config.py
+++ b/services/boost/src/config.py
@@ -232,8 +232,8 @@ HARBOR_MINIMAX_API_KEY = Config[str](
     description="""
 MiniMax API key. When set, the MiniMax OpenAI-compatible
 endpoint (https://api.minimax.io/v1) is automatically
-registered as a boost backend with MiniMax-M2.7,
-MiniMax-M2.7-highspeed, and previous MiniMax models.
+registered as a boost backend with MiniMax-M3 (default),
+MiniMax-M2.7, and MiniMax-M2.7-highspeed.
 """.strip(),
 )
 
@@ -243,16 +243,10 @@ MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 # expose a /models endpoint.
 MINIMAX_MODELS = (
     [
+        {"id": "MiniMax-M3", "object": "model", "created": 0, "owned_by": "minimax"},
         {"id": "MiniMax-M2.7", "object": "model", "created": 0, "owned_by": "minimax"},
         {
             "id": "MiniMax-M2.7-highspeed",
-            "object": "model",
-            "created": 0,
-            "owned_by": "minimax",
-        },
-        {"id": "MiniMax-M2.5", "object": "model", "created": 0, "owned_by": "minimax"},
-        {
-            "id": "MiniMax-M2.5-highspeed",
             "object": "model",
             "created": 0,
             "owned_by": "minimax",

--- a/services/boost/tests/test_minimax_config.py
+++ b/services/boost/tests/test_minimax_config.py
@@ -71,18 +71,20 @@ class TestMiniMaxAutoConfig(unittest.TestCase):
         config = self._reload_config()
 
         model_ids = [m['id'] for m in config.MINIMAX_MODELS]
+        self.assertIn('MiniMax-M3', model_ids)
         self.assertIn('MiniMax-M2.7', model_ids)
         self.assertIn('MiniMax-M2.7-highspeed', model_ids)
-        self.assertIn('MiniMax-M2.5', model_ids)
-        self.assertIn('MiniMax-M2.5-highspeed', model_ids)
+        self.assertNotIn('MiniMax-M2.5', model_ids)
+        self.assertNotIn('MiniMax-M2.5-highspeed', model_ids)
 
     @patch.dict(os.environ, {'HARBOR_MINIMAX_API_KEY': 'sk-test-key'}, clear=False)
-    def test_minimax_m27_is_first_model(self):
+    def test_minimax_m3_is_first_model(self):
         config = self._reload_config()
 
         model_ids = [m['id'] for m in config.MINIMAX_MODELS]
-        self.assertEqual(model_ids[0], 'MiniMax-M2.7')
-        self.assertEqual(model_ids[1], 'MiniMax-M2.7-highspeed')
+        self.assertEqual(model_ids[0], 'MiniMax-M3')
+        self.assertEqual(model_ids[1], 'MiniMax-M2.7')
+        self.assertEqual(model_ids[2], 'MiniMax-M2.7-highspeed')
 
     @patch.dict(os.environ, {'HARBOR_MINIMAX_API_KEY': ''}, clear=False)
     def test_minimax_static_models_empty_when_no_key(self):

--- a/services/boost/tests/test_minimax_integration.py
+++ b/services/boost/tests/test_minimax_integration.py
@@ -20,6 +20,25 @@ MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
 class TestMiniMaxIntegration(unittest.TestCase):
     """Integration tests verifying MiniMax API connectivity."""
 
+    def test_chat_completion_m3(self):
+        body = json.dumps({
+            'model': 'MiniMax-M3',
+            'messages': [{'role': 'user', 'content': 'Say hello in one word.'}],
+            'max_tokens': 20,
+            'temperature': 1.0,
+        }).encode()
+        req = urllib.request.Request(
+            f'{MINIMAX_BASE_URL}/chat/completions',
+            data=body,
+            headers={
+                'Authorization': f'Bearer {MINIMAX_API_KEY}',
+                'Content-Type': 'application/json',
+            },
+        )
+        resp = json.loads(urllib.request.urlopen(req, timeout=60).read())
+        content = resp['choices'][0]['message']['content']
+        self.assertTrue(len(content) > 0)
+
     def test_chat_completion_m27(self):
         body = json.dumps({
             'model': 'MiniMax-M2.7',
@@ -39,28 +58,9 @@ class TestMiniMaxIntegration(unittest.TestCase):
         content = resp['choices'][0]['message']['content']
         self.assertTrue(len(content) > 0)
 
-    def test_chat_completion_m25(self):
+    def test_chat_completion_m27_highspeed(self):
         body = json.dumps({
-            'model': 'MiniMax-M2.5',
-            'messages': [{'role': 'user', 'content': 'Say hello in one word.'}],
-            'max_tokens': 20,
-            'temperature': 1.0,
-        }).encode()
-        req = urllib.request.Request(
-            f'{MINIMAX_BASE_URL}/chat/completions',
-            data=body,
-            headers={
-                'Authorization': f'Bearer {MINIMAX_API_KEY}',
-                'Content-Type': 'application/json',
-            },
-        )
-        resp = json.loads(urllib.request.urlopen(req, timeout=60).read())
-        content = resp['choices'][0]['message']['content']
-        self.assertTrue(len(content) > 0)
-
-    def test_chat_completion_m25_highspeed(self):
-        body = json.dumps({
-            'model': 'MiniMax-M2.5-highspeed',
+            'model': 'MiniMax-M2.7-highspeed',
             'messages': [{'role': 'user', 'content': 'Say hi in one word.'}],
             'max_tokens': 20,
             'temperature': 1.0,
@@ -87,10 +87,9 @@ class TestMiniMaxIntegration(unittest.TestCase):
 
             self.assertIn(MINIMAX_BASE_URL, config.BOOST_APIS)
             model_ids = [m['id'] for m in config.MINIMAX_MODELS]
+            self.assertIn('MiniMax-M3', model_ids)
             self.assertIn('MiniMax-M2.7', model_ids)
             self.assertIn('MiniMax-M2.7-highspeed', model_ids)
-            self.assertIn('MiniMax-M2.5', model_ids)
-            self.assertIn('MiniMax-M2.5-highspeed', model_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Upgrade the auto-registered MiniMax static model list in `boost` to use the latest **MiniMax-M3** as the new default, retain the **MiniMax-M2.7** line as an alternative, and drop the deprecated **MiniMax-M2.5** entries.

## Changes
- `services/boost/src/config.py`
  - Add `MiniMax-M3` at the head of `MINIMAX_MODELS` so it surfaces first in `/v1/models`
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
  - Remove `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`
  - Refresh `HARBOR_MINIMAX_API_KEY` description text
- `docs/5.2.2-Harbor-Boost-Configuration.md` — mirrored doc snippet updated
- `services/boost/tests/test_minimax_config.py` — assertions updated for M3-first ordering, with explicit `assertNotIn` for the removed M2.5 entries
- `services/boost/tests/test_minimax_integration.py` — added `test_chat_completion_m3`; old M2.5 integration tests replaced

The Anthropic-compatible base URL, TTS-related config, the `HARBOR_MINIMAX_API_KEY` plumbing into `BOOST_APIS` / `BOOST_KEYS`, and the cross-service hook-ups (`lobechat`, `browseruse`) are unchanged — only the static model catalogue moves to M3.

## Why
MiniMax-M3 is the new flagship model — 512K context window, up to 128K max output, image input support across both OpenAI-compatible and Anthropic-compatible interfaces — so it is the natural default when `HARBOR_MINIMAX_API_KEY` is configured. Keeping M2.7 in the list lets users opt back into the previous generation without extra config.

## Testing
- `python3 -m unittest test_minimax_config -v` — all 9 unit tests pass locally
- The MiniMax-M3 endpoint reachable at `https://api.minimax.io/v1/chat/completions` (verified directly; integration tests gated on live billing)