### PR TITLE
fix: document and wire BionicGPT Ollama setup

### DIFF
--- a/.facts
+++ b/.facts
@@ -213,6 +213,12 @@
 - label: README introduces harbor launch with backend model --web --config and --service examples
   command: rg -q 'harbor launch --backend ollama' README.md && rg -q 'harbor launch --service opencode' README.md
   tags: [implemented]
+- label: BionicGPT docs explain how to configure Ollama from inside Harbor by using the internal Ollama URL with /v1, a non-empty API key, and an available Ollama model name
+  command: grep -q 'http://ollama:11434/v1' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -q 'sk-ollama' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -q 'harbor url -i ollama' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -Eq 'harbor ollama (list|ls)' 'docs/2.1.8-Frontend&colon-BionicGPT.md'
+  tags: [implemented]
+- label: BionicGPT compose exposes upstream default DNS names for its bundled LLM and embeddings APIs
+  command: grep -A10 '^  bionicgpt-llmapi:' services/compose.bionicgpt.yml | grep -q 'llm-api' && grep -A10 '^  bionicgpt-embeddingsapi:' services/compose.bionicgpt.yml | grep -q 'embeddings-api'
+  tags: [implemented]
 
 # ci
 - label: CI includes GitHub Actions workflows for app-release bench-docker boost-docker lint and test

--- a/docs/2.1.8-Frontend&colon-BionicGPT.md
+++ b/docs/2.1.8-Frontend&colon-BionicGPT.md
@@ -20,4 +20,32 @@ harbor up bionicgpt
 
 Harbor can't configure BionicGPT ahead of time as connectivity configuration is stored in Postgres and can be adjusted via the UI after service starts.
 
-BionicGPT supports `ollama` and Open-AI compatible backends out of the box.
+BionicGPT supports `ollama` and OpenAI-compatible backends out of the box.
+
+#### Ollama
+
+When configuring Ollama in BionicGPT, use Harbor's internal Ollama URL because BionicGPT runs inside the Harbor Docker network. Start Ollama with BionicGPT, then get the internal URL:
+
+```bash
+harbor up bionicgpt ollama
+harbor url -i ollama
+```
+
+Use that value with `/v1` appended as the OpenAI-compatible base URL. On current Harbor, it resolves through Docker Compose service DNS as:
+
+```text
+http://ollama:11434/v1
+```
+
+BionicGPT also expects a non-empty API key for OpenAI-compatible providers; use a placeholder such as `sk-ollama`. For the model name, choose a model already available in Ollama:
+
+```bash
+harbor ollama list
+harbor ollama ls
+```
+
+If the model is missing, pull it first:
+
+```bash
+harbor ollama pull llama3.2:3b
+```

--- a/services/compose.bionicgpt.yml
+++ b/services/compose.bionicgpt.yml
@@ -38,7 +38,9 @@ services:
       - ./.env
       - ./services/bionicgpt/override.env
     networks:
-      - harbor-network
+      harbor-network:
+        aliases:
+          - llm-api
 
   bionicgpt-embeddingsapi:
     container_name: ${HARBOR_CONTAINER_PREFIX}.bionicgpt-embeddingsapi
@@ -47,7 +49,9 @@ services:
       - ./.env
       - ./services/bionicgpt/override.env
     networks:
-      - harbor-network
+      harbor-network:
+        aliases:
+          - embeddings-api
 
   bionicgpt-chunkingengine:
     container_name: ${HARBOR_CONTAINER_PREFIX}.bionicgpt-chunkingengine


### PR DESCRIPTION
## Summary
- Add BionicGPT UI guidance for configuring Harbor's Ollama backend.
- Document the internal OpenAI-compatible endpoint (`harbor url -i ollama` + `/v1`), API key, and model pull/list steps.
- Add Docker network aliases so BionicGPT's bundled upstream default service URLs (`llm-api`, `embeddings-api`) resolve inside the Harbor network.
- Add command-backed `.facts` entries for the new documentation and compose guarantees.

## Test plan
- `git diff --check 8c6b3ec0..HEAD`
- YAML parse of `services/compose.bionicgpt.yml`
- `grep -q 'http://ollama:11434/v1' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -q 'sk-ollama' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -q 'harbor url -i ollama' 'docs/2.1.8-Frontend&colon-BionicGPT.md' && grep -Eq 'harbor ollama (list|ls)' 'docs/2.1.8-Frontend&colon-BionicGPT.md'`
- `grep -A10 '^  bionicgpt-llmapi:' services/compose.bionicgpt.yml | grep -q 'llm-api' && grep -A10 '^  bionicgpt-embeddingsapi:' services/compose.bionicgpt.yml | grep -q 'embeddings-api'`
- Windows amd64 Docker Desktop E2E smoke using the BionicGPT + Ollama compose file set:
  - BionicGPT/Postgres/Ollama stack started successfully.
  - `harbor.bionicgpt-postgres`, `harbor.ollama`, and `harbor.ollama-init` healthy; migrations exited `0`; BionicGPT app/Envoy/barricade/pipeline/llmapi/embeddings/chunking running.
  - Docker network aliases included `llm-api` and `embeddings-api` after this patch.
  - `GET http://127.0.0.1:33821/` returned `Ollama is running`.
  - BionicGPT sign-up/login succeeded and the AI Chat Console rendered.
  - BionicGPT Model Setup accepted `qwen2.5:0.5b` with base URL `http://ollama:11434/v1` and API key `sk-ollama`.
  - A smoke assistant using that model submitted `Reply with exactly HERMES_OK.`.
  - `POST /completions/34` streamed OpenAI-compatible SSE chunks from Ollama model `qwen2.5:0.5b`: `HER` + `MES` + `_OK`.
  - `POST /app/team/1/update_response` saved `HERMES_OK`; the console then displayed `Model: qwen2.5:0.5b` and `HERMES_OK` without `Processing prompt`.

Facts verification: built the Harbor facts container on Windows Docker Desktop (`facts 0.7.1`) and ran `facts check --id 997 --id si6 --timeout 60`: `2 passed, 0 failed`.

Closes #38
