### PR TITLE
fix(gptme): document container-safe tool allowlist

### DIFF
--- a/docs/2.3.36-Satellite-gptme.md
+++ b/docs/2.3.36-Satellite-gptme.md
@@ -30,6 +30,7 @@ harbor gptme "Summarize" README.md
 - Harbor will mount the current directory as a working directory for `gptme`
   - It means that `gptme` will only see the current folder and its subfolders, but not the rest of your filesystem
 - `gptme` runs in a container, so the functionality related to interactions with the host OS will not work (opening a browser, etc.)
+  - If you customize the global config, keep browser/display tools such as `browser`, `screenshot`, and `vision` out of `TOOL_ALLOWLIST`
 - Harbor will pre-configure `gptme` to use Ollama as OpenAI-compatible backend when started together
 - `gptme` requires a fairly large context window, Ollama's default 2k is almost never enough for the tools to work properly
 

--- a/services/gptme/config.toml
+++ b/services/gptme/config.toml
@@ -22,5 +22,6 @@
 
 # Uncomment to change tool configuration
 #TOOL_FORMAT = "markdown" # Select the tool formal. One of `markdown`, `xml`, `tool`
-#TOOL_ALLOWLIST = "save,append,patch,ipython,shell,browser"  # Comma separated list of allowed tools
+# Browser/display tools (browser, screenshot, vision) are not available in the container.
+#TOOL_ALLOWLIST = "save,append,patch,patch_many,ipython,shell,morph"  # Comma separated list of allowed tools
 #TOOL_MODULES = "gptme.tools,custom.tools" # List of python comma separated python module path


### PR DESCRIPTION
## Summary
- replace the commented gptme TOOL_ALLOWLIST example with container-safe tools
- document that browser/display tools (`browser`, `screenshot`, `vision`) are unavailable in the container
- add the same warning to the gptme satellite docs near the existing container limitation note

## Verification
- `git diff --check`

I left the broader `gptme-server`/HTTP mode idea out of scope for this PR.