### PR TITLE
fix(agent): drop archived neofetch, fix broken node/yarn install

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -14,7 +14,7 @@ RUN sudo apt-get update \
   wmctrl \
   libreoffice \
   fonts-noto-cjk \
-  neofetch \
+  nodejs \
   python3-pip \
   python3-requests \
   python3-numpy \
@@ -26,7 +26,7 @@ RUN sudo apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://npmjs.org/install.sh | sh
-RUN npm install -g --unsafe-perm yarn
+RUN npm install -g yarn
 RUN sudo chown -R abc:abc /usr/lib/node_modules
 
 # This is an alternative for CMD, as Webtop has


### PR DESCRIPTION
## What

`services/agent/Dockerfile` fails to build. `apt-get install` includes `neofetch`, which has been dropped from the Ubuntu archives the `linuxserver/webtop` base image tracks, so the build exits with `E: Unable to locate package neofetch` (exit code 100) before it gets anywhere near the agent sources.

Fixing that surfaces two more breaks further down the same build:

- `curl -L https://npmjs.org/install.sh | sh` refuses to run with "npm cannot be installed without node.js" because nothing in the image installs Node.js.
- `npm install -g --unsafe-perm yarn` fails with "Unknown cli flag: --unsafe-perm" because the npm version the install script fetches no longer accepts that flag.

## Fix

- Drop `neofetch` in favor of `nodejs` in the `apt-get install` list (`neofetch` is a display tool and nothing else in the image or the agent sources references it).
- Drop `--unsafe-perm` from the `yarn` install.

## Verification

- `docker build` against unpatched `services/agent/Dockerfile` (build context `services/agent`, HEAD `ff2314e`): fails at the `apt-get install` step with `E: Unable to locate package neofetch`.
- Same build against the patched Dockerfile: completes end to end (`Successfully built`), and `node --version` / `npm --version` / `yarn --version` all resolve inside the built image.
- Checked `.github/workflows/*.yml`: no lint or test workflow's path filters cover `services/agent/**`, and `harbor.sh dev lint` has no Dockerfile pass, so there is no CI gate on this file; the Docker build above is the verification.

Fixes #240
